### PR TITLE
Swap pointers instead of resetting #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ LRU.prototype.set = function (key, value) {
         }
     }
 
-    element.value = value
     element.next = null;
     element.prev = this.head;
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ LRU.prototype.remove = function (key) {
 LRU.prototype.set = function (key, value) {
     if( this.cache.hasOwnProperty(key) ) {
         element = this.cache[key]
+        element.value = value
 
         // If it's already the head, there's nothing more to do:
         if( key === this.head ) {

--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ LRU.prototype.set = function (key, value) {
             return value;
         }
     } else {
-        element = this.remove(key);
-        element = element || { value:value };
+        element = { value:value };
 
         this.cache[key] = element;
 

--- a/index.js
+++ b/index.js
@@ -12,14 +12,19 @@ util.inherits(LRU, events.EventEmitter);
 
 LRU.prototype.remove = function (key) {
     var element = this.cache[key];
+
     if(element) {
         delete this.cache[key];
+
         --this.length;
+
         if(element.prev) this.cache[element.prev].next = element.next;
         if(element.next) this.cache[element.next].prev = element.prev;
+
         if(this.head == key) {
             this.head = element.prev;
         }
+
         if(this.tail == key) {
             this.tail = element.next;
         }
@@ -28,14 +33,28 @@ LRU.prototype.remove = function (key) {
 }
 
 LRU.prototype.set = function (key, value) {
-    element = this.remove(key);
-    element = element || { value:value };
+    if( this.cache.hasOwnProperty(key) ) {
+        element = this.cache[key]
+
+        // If it's already the head, there's nothing more to do:
+        if( key === this.head ) {
+            return value;
+        }
+    } else {
+        element = this.remove(key);
+        element = element || { value:value };
+
+        this.cache[key] = element;
+
+        // Eviction is only possible if the key didn't already exist:
+        if (++this.length > this.max) {
+            this.evict();
+        }
+    }
 
     element.value = value
     element.next = null;
     element.prev = this.head;
-
-    this.cache[key] = element;
 
     if (this.head) {
         this.cache[this.head].next = key;
@@ -46,10 +65,6 @@ LRU.prototype.set = function (key, value) {
       this.tail = key;
     }
 
-    if (++this.length > this.max) {
-        this.evict();
-    }
-
     return value
 };
 
@@ -57,7 +72,25 @@ LRU.prototype.get = function (key) {
     var element = this.cache[key];
     if (!element) { return; }
 
-    this.set(key, element.value);
+    if( this.length > 1 ) {
+        // Tail only changes if this was the tail:
+        if( key === this.tail ) this.tail = element.next
+
+        if( this.head !== key ) {
+            // Set prev -> next:
+            if( element.prev ) this.cache[element.prev].next = element.next
+
+            // Set prevhead->next:
+            if( this.head ) this.cache[this.head].next = key
+        }
+
+        // Set next -> prev:
+        if( element.next ) this.cache[element.next].prev = element.prev
+
+        // Set new head:
+        this.head = key
+    }
+
     return element.value;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lru",
   "description": "A simple O(1) LRU cache",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Chris O'Hara <cohara87@gmail.com>",
   "main": "index",
   "bugs": {

--- a/test/lru-test.js
+++ b/test/lru-test.js
@@ -54,6 +54,17 @@ suite.addBatch({
     assert.deepEqual(['foo3','foo4'], keys(lru.cache));
   }
 })
+
+suite.addBatch({
+  "ovrewriting a key updates the value": function() {
+    var lru = new LRU(2);
+    lru.set('foo1', 'bar1');
+    assert.equal('bar1', lru.get('foo1'))
+    lru.set('foo1', 'bar2');
+    assert.equal('bar2', lru.get('foo1'))
+  }
+})
+
 suite.addBatch({
   "lru invariant is maintained for get()": function() {
     var lru = new LRU(2);
@@ -68,6 +79,7 @@ suite.addBatch({
     assert.deepEqual(['foo1','foo3'], keys(lru.cache));
   }
 });
+
 suite.addBatch({
   "lru invariant is maintained for get()": function() {
     var lru = new LRU(2);


### PR DESCRIPTION
Did as requested in #3 and swapped pointers when getting instead of resetting the key. Also modified `set` to skip a couple unnecessary operations if you're just overwriting a key —, although in hindsight the difference is negligible. Outward behavior is unchanged so incremented package version to `0.2.1`.