### PR TITLE
add options.maxAge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ cache.length               // => 1
 
 #### `LRU( length )`
 Create a new LRU cache that stores `length` elements before evicting the least recently used.
+Optionally you can pass a an options map with additional options instead
+
+``` js
+{
+  max: maxElementsToStore,
+  maxAge: maxAgeInMilliseconds
+}
+```
+
+If you pass `maxAge` items will be evicted if they are older than `maxAge` when you access them.
 
 **Returns**: the newly created LRU cache
 

--- a/test/lru-test.js
+++ b/test/lru-test.js
@@ -126,6 +126,17 @@ suite.addBatch({
   }
 });
 
+// suite.addBatch({
+//   "invalidate entries if they are older than maxAge": function() {
+//     var lru = new LRU({maxAge: 5});
+//     lru.set('foo', 'bar');
+//     assert.equal(lru.get('foo'), 'bar');
+//     setTimeout(function () {
+//       assert.equal(lru.get('foo'), null);
+//     }, 50);
+//   }
+// });
+
 suite.addBatch({
   "idempotent 'changes'": {
     "set() and remove() on empty LRU is idempotent": function() {


### PR DESCRIPTION
added a maxAge option to the constructor that will evict items older than maxAge when you access them. to support this i made the constructor accept an options map in addition to the maxLength argument. i've added docs and a test as well but i couldn't figure out how to make vows work with async testing so it's commented out for now. maybe you know the trick to getting it to work?

anyways here is an example

``` js
var lru = LRU({maxAge: 1000})

lru.set('hello', 'world')
console.log(lru.get('hello')) // prints world
setTimeout(function () {
  console.log(lru.get('hello')) // prints undefined
}, 2000)
```