### PR TITLE
Fix set get remove

### DIFF
--- a/test/lru-test.js
+++ b/test/lru-test.js
@@ -77,6 +77,16 @@ suite.addBatch({
     lru.set('foo3', 'bar3');
 
     assert.deepEqual(['foo1','foo3'], keys(lru.cache));
+  },
+  "lru invariant is maintained after set(), get() and remove()": function() {
+    var lru = new LRU(2);
+    lru.set('a', 1);
+    lru.set('b', 2);
+    assert.deepEqual(lru.get('a'), 1);
+    lru.remove('a');
+    lru.set('c', 1);
+    lru.set('d', 1);
+    assert.deepEqual(['c','d'], keys(lru.cache));
   }
 });
 


### PR DESCRIPTION
We use this module in [bittorrent-dht](https://github.com/feross/bittorrent-dht) and I started to notice some weird errors. The errors were caused by the linked list getting corrupted after a set, get and remove sequence.

I've added a test for this and another commit that fixes the issue. I quick merge on this would be appreciated. Also if you're up for it, feel free to add me as collaborator on this repo if you want some help maintaining this :)