### PR TITLE
Make .remove only return the value

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cache.get('foo2'); //=> bar2
 
 cache.set('foo3', 'bar3'); // => evicted = { key: 'foo', value: 'bar' }
 cache.get('foo3');         // => 'bar3'
-cache.remove('foo2')       // => {key: 'foo2', value: 'bar2'}
+cache.remove('foo2')       // => 'bar2'
 cache.remove('foo4')       // => undefined
 cache.length               // => 1
 ```
@@ -60,9 +60,6 @@ Set the value of the key and mark the key as most recently used.
 
 **Returns**: `value`
 
-##### `.set( key, value )`
-Set the value of the key and mark the key as most recently used.
-
 ##### `.get( key )`
 Query the value of the key and mark the key as most recently used.
 
@@ -74,9 +71,9 @@ Query the value of the key without marking the key as most recently used.
 **Returns**: value of key if found; `undefined` otherwise.
 
 ##### `.remove( key )`
-Remove the key/value pair from the cache.
+Remove the value from the cache.
 
-**Returns**: an associative array containing `{key: <key>, value: <value>}`
+**Returns**: value of key if found; `undefined` otherwise.
 
 ##### `.on( event, callback )`
 Respond to events. Currently only the `evict` event is implemented. When a key is evicted, the callback is executed with an associative array containing the evicted key: `{key: key, value: value}`.

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ LRU.prototype.remove = function (key) {
         }
     }
 
-    return element;
+    return element.value;
 }
 
 LRU.prototype.peek = function (key) {
@@ -117,6 +117,6 @@ LRU.prototype.get = function (key) {
 LRU.prototype.evict = function () {
     if(!this.tail) { return; }
     var key = this.tail;
-    var element = this.remove(this.tail);
-    this.emit('evict', {key:key, value:element.value});
+    var removedValue = this.remove(this.tail);
+    this.emit('evict', {key:key, value:removedValue});
 };


### PR DESCRIPTION
Updates `.remove` method so that it returns the value instead of the element.
Also updates the readme.

Implements https://github.com/chriso/lru/issues/15.