### PR TITLE
Fix .set method

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ LRU.prototype.peek = function (key) {
 }
 
 LRU.prototype.set = function (key, value) {
+    var element;
     if( this.cache.hasOwnProperty(key) ) {
         element = this.cache[key]
         element.value = value


### PR DESCRIPTION
Calling `.set` was creating a global variable `element`:

```
var cache = LRU(3);
cache.set('foo', 'bar');
console.log(element); // => { value: 'bar', next: null, prev: null }
```

This fixes the issue by adding a `var element` to the beginning of `.set`.