### PR TITLE
Add `clear` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ cache.get('foo3');         // => 'bar3'
 cache.remove('foo2')       // => 'bar2'
 cache.remove('foo4')       // => undefined
 cache.length               // => 1
+cache.keys                 // => ['foo3']
+
+cache.clear()              // => it will NOT emit the 'evict' event
+cache.length               // => 0
+cache.keys                 // => []
 ```
 
 ### API
@@ -76,7 +81,11 @@ Query the value of the key without marking the key as most recently used.
 ##### `.remove( key )`
 Remove the value from the cache.
 
+
 **Returns**: value of key if found; `undefined` otherwise.
+
+##### `.clear()`
+Clear the cache. This method does **NOT** emit the `evict` event.
 
 ##### `.on( event, callback )`
 Respond to events. Currently only the `evict` event is implemented. When a key is evicted, the callback is executed with an associative array containing the evicted key: `{key: key, value: value}`.

--- a/example/usage.js
+++ b/example/usage.js
@@ -21,3 +21,6 @@ console.log(cache.remove('foo2')) // => { key: 'foo2', value: 'bar2' }
 console.log(cache.remove('foo4')) // => undefined
 console.log(cache.length)         // => 1
 console.log(evicted)              // => evicted = { key: 'foo', value: 'bar' }
+
+cache.clear()                     // it will NOT emit the 'evict' event
+console.log(cache.length)         // => 0

--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ Object.defineProperty(LRU.prototype, 'keys', {
   get: function () { return Object.keys(this.cache) }
 })
 
+LRU.prototype.clear = function () {
+  this.cache = {}
+  this.head = this.tail = null
+  this.length = 0
+}
+
 LRU.prototype.remove = function (key) {
   if (typeof key !== 'string') key = '' + key
   if (!this.cache.hasOwnProperty(key)) return

--- a/test/lru-test.js
+++ b/test/lru-test.js
@@ -5,6 +5,20 @@ var LRU = require('../')
 var suite = vows.describe('LRU')
 
 suite.addBatch({
+  'clear() sets the cache to its initial state': function () {
+    var lru = new LRU(2)
+
+    var json1 = JSON.stringify(lru)
+
+    lru.set('foo', 'bar')
+    lru.clear()
+    var json2 = JSON.stringify(lru)
+
+    assert.equal(json2, json1)
+  }
+})
+
+suite.addBatch({
   'setting keys doesn\'t grow past max size': function () {
     var lru = new LRU(3)
     assert.equal(0, lru.length)


### PR DESCRIPTION
This method sets the cache to it's initial state. It will **NOT** emit the `evict` event.