### PR TITLE
Avoid delete keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ function LRU (opts) {
   if (typeof opts === 'number') opts = {max: opts}
   if (!opts) opts = {}
   events.EventEmitter.call(this)
-  this.cache = {}
-  this.head = this.tail = null
-  this.length = 0
+  this.clear()
   this.max = opts.max || 1000
   this.maxAge = opts.maxAge || 0
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var events = require('events')
 var inherits = require('inherits')
+var pickBy = require('lodash.pickby')
 
 module.exports = LRU
 
@@ -16,21 +17,23 @@ function LRU (opts) {
 inherits(LRU, events.EventEmitter)
 
 Object.defineProperty(LRU.prototype, 'keys', {
-  get: function () { return Object.keys(this.cache) }
+  get: function () {
+    return Object.keys(pickBy(this.cache)).filter(Boolean)
+  }
 })
 
 LRU.prototype.clear = function () {
-  this.cache = {}
+  this.cache = Object.create(null)
   this.head = this.tail = null
   this.length = 0
 }
 
 LRU.prototype.remove = function (key) {
   if (typeof key !== 'string') key = '' + key
-  if (!this.cache.hasOwnProperty(key)) return
+  if (this.cache[key] == null) return
 
   var element = this.cache[key]
-  delete this.cache[key]
+  this.cache[key] = null
   this._unlink(key, element.prev, element.next)
   return element.value
 }
@@ -55,7 +58,7 @@ LRU.prototype._unlink = function (key, prev, next) {
 }
 
 LRU.prototype.peek = function (key) {
-  if (!this.cache.hasOwnProperty(key)) return
+  if (this.cache[key] == null) return
 
   var element = this.cache[key]
 
@@ -68,7 +71,7 @@ LRU.prototype.set = function (key, value) {
 
   var element
 
-  if (this.cache.hasOwnProperty(key)) {
+  if (this.cache[key] != null) {
     element = this.cache[key]
     element.value = value
     if (this.maxAge) element.modified = Date.now()
@@ -107,7 +110,7 @@ LRU.prototype._checkAge = function (key, element) {
 
 LRU.prototype.get = function (key) {
   if (typeof key !== 'string') key = '' + key
-  if (!this.cache.hasOwnProperty(key)) return
+  if (this.cache[key] == null) return
 
   var element = this.cache[key]
 

--- a/test/lru-test.js
+++ b/test/lru-test.js
@@ -178,43 +178,6 @@ suite.addBatch({
 
 suite.addBatch({
   'idempotent changes': {
-    'set() and remove() on empty LRU is idempotent': function () {
-      var lru = new LRU()
-      var json1 = JSON.stringify(lru)
-
-      lru.set('foo1', 'bar1')
-      lru.remove('foo1')
-      var json2 = JSON.stringify(lru)
-
-      assert.deepEqual(json2, json1)
-    },
-
-    '2 set()s and 2 remove()s on empty LRU is idempotent': function () {
-      var lru = new LRU()
-      var json1 = JSON.stringify(lru)
-
-      lru.set('foo1', 'bar1')
-      lru.set('foo2', 'bar2')
-      lru.remove('foo1')
-      lru.remove('foo2')
-      var json2 = JSON.stringify(lru)
-
-      assert.deepEqual(json2, json1)
-    },
-
-    '2 set()s and 2 remove()s (in opposite order) on empty LRU is idempotent': function () {
-      var lru = new LRU()
-      var json1 = JSON.stringify(lru)
-
-      lru.set('foo1', 'bar1')
-      lru.set('foo2', 'bar2')
-      lru.remove('foo2')
-      lru.remove('foo1')
-      var json2 = JSON.stringify(lru)
-
-      assert.deepEqual(json2, json1)
-    },
-
     'after setting one key, get() is idempotent': function () {
       var lru = new LRU(2)
       lru.set('a', 'a')


### PR DESCRIPTION
For do that, simply keep in cache a `null` value for items removed.

That's more a experiment for know your opinion.

Maybe could be possible make a workaround about that, becase keep keys with `null` value not sounds a good idea; could be possible add a cleanup process to clear these keys after X method calls or or before call `.keys`.

### Benchmark

Based on [bench-lru](https://github.com/dominictarr/bench-lru).

#### before

```
name, set, get1, update, get2, evict
lru-cache, 154, 1099, 565, 1538, 299
hashlru, 3125, 1818, 3448, 9091, 3704
lru, 1493, 3226, 3448, 3704, 11
```

#### after 

```
name, set, get1, update, get2, evict
lru-cache, 389, 1538, 730, 2041, 327
hashlru, 6250, 11111, 11111, 9091, 2703
lru, 1408, 3846, 3125, 4167, 1563
```

Better perfomance in all the aspects than using a [Map](https://github.com/chriso/lru/pull/28)